### PR TITLE
feat(transactions): add manual transaction flow

### DIFF
--- a/src/app/(app)/transactions/_components/transactions-page-view.tsx
+++ b/src/app/(app)/transactions/_components/transactions-page-view.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   CalendarDays,
   ChevronDown,
   LoaderCircle,
+  Plus,
   SlidersHorizontal,
   Tag,
   Trash2,
@@ -182,13 +184,29 @@ export function TransactionsPageView({
         eyebrow="Transaction workspace"
         title="Transactions"
         description="Search, filter, and review transactions."
+        actions={
+          <Button asChild className="w-full">
+            <Link href="/transactions/new">
+              <Plus className="h-4 w-4" /> Add Transaction
+            </Link>
+          </Button>
+        }
       />
       <div className="hidden lg:block">
         <AppPageHeader
           eyebrow="Transaction workspace"
           title="Transactions"
           description="Search, filter, and review transactions."
-          actions={<TransactionsTimeframePicker filters={data.filters} />}
+          actions={
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <TransactionsTimeframePicker filters={data.filters} />
+              <Button asChild>
+                <Link href="/transactions/new">
+                  <Plus className="h-4 w-4" /> Add Transaction
+                </Link>
+              </Button>
+            </div>
+          }
         />
       </div>
 

--- a/src/app/(app)/transactions/new/_components/create-recipient-dialog.tsx
+++ b/src/app/(app)/transactions/new/_components/create-recipient-dialog.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { LoaderCircle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useCreateRecipientMutation } from "@/features/recipients/mutations";
+import type {
+  RecipientCreateConflict,
+  RecipientCreateDto,
+} from "@/features/recipients/types";
+import { ApiClientError, getApiClientErrorMessage } from "@/lib/api/client";
+
+const inputClassName =
+  "min-h-11 w-full rounded-[8px] border border-input bg-background/18 px-3.5 text-sm text-foreground outline-none transition-colors placeholder:text-secondary-foreground/85 focus-visible:ring-2 focus-visible:ring-ring";
+
+export function CreateRecipientDialog({
+  open,
+  suggestedName,
+  onOpenChange,
+  onSelect,
+}: {
+  open: boolean;
+  suggestedName: string;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (
+    recipient: Pick<RecipientCreateDto, "uuid" | "displayName">,
+  ) => void;
+}) {
+  const [displayName, setDisplayName] = useState(suggestedName);
+  const [error, setError] = useState<string | null>(null);
+  const [conflict, setConflict] = useState<
+    RecipientCreateConflict["existingRecipient"] | null
+  >(null);
+  const mutation = useCreateRecipientMutation();
+
+  useEffect(() => {
+    if (!open) return;
+    setDisplayName(suggestedName);
+    setError(null);
+    setConflict(null);
+  }, [open, suggestedName]);
+
+  function handleOpenChange(nextOpen: boolean) {
+    onOpenChange(nextOpen);
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const name = displayName.trim();
+    if (!name) {
+      setError("Recipient name is required");
+      return;
+    }
+
+    setError(null);
+    setConflict(null);
+    try {
+      const recipient = await mutation.mutateAsync({ displayName: name });
+      onSelect(recipient);
+      onOpenChange(false);
+    } catch (caught) {
+      if (caught instanceof ApiClientError && caught.status === 409) {
+        const details = caught.body?.details;
+        if (
+          details &&
+          typeof details === "object" &&
+          "existingRecipient" in details
+        ) {
+          const existing = details.existingRecipient;
+          if (
+            existing &&
+            typeof existing === "object" &&
+            "uuid" in existing &&
+            "displayName" in existing &&
+            typeof existing.uuid === "string" &&
+            typeof existing.displayName === "string"
+          ) {
+            setConflict({
+              uuid: existing.uuid,
+              displayName: existing.displayName,
+            });
+            return;
+          }
+        }
+      }
+      setError(
+        getApiClientErrorMessage(
+          caught,
+          "Unable to create this recipient right now.",
+        ),
+      );
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Create Recipient</DialogTitle>
+            <DialogDescription>
+              Add a recipient to your workspace and select it for this
+              transaction.
+            </DialogDescription>
+          </DialogHeader>
+
+          <label className="mt-5 block text-sm font-medium text-foreground">
+            Recipient name
+            <input
+              name="displayName"
+              autoComplete="off"
+              value={displayName}
+              onChange={(event) => setDisplayName(event.target.value)}
+              className={`${inputClassName} mt-2`}
+              aria-invalid={Boolean(error)}
+              aria-describedby={error ? "recipient-create-error" : undefined}
+            />
+          </label>
+
+          {conflict ? (
+            <div className="mt-4 rounded-[8px] border border-accent/35 bg-accent/10 p-4">
+              <p className="text-sm font-semibold text-foreground">
+                A matching recipient exists
+              </p>
+              <p className="mt-1 break-words text-sm text-secondary-foreground">
+                {conflict.displayName}
+              </p>
+              <Button
+                type="button"
+                className="mt-3 w-full sm:w-auto"
+                onClick={() => {
+                  onSelect(conflict);
+                  onOpenChange(false);
+                }}
+              >
+                Use Existing Recipient
+              </Button>
+            </div>
+          ) : null}
+
+          {error ? (
+            <p
+              id="recipient-create-error"
+              role="alert"
+              className="mt-3 text-sm text-destructive"
+            >
+              {error}
+            </p>
+          ) : null}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={mutation.isPending}>
+              {mutation.isPending ? (
+                <LoaderCircle className="h-4 w-4 animate-spin" />
+              ) : null}
+              {mutation.isPending ? "Creating…" : "Create Recipient"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(app)/transactions/new/_components/recipient-picker.tsx
+++ b/src/app/(app)/transactions/new/_components/recipient-picker.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useEffect, useRef, useState, type Ref } from "react";
+import { LoaderCircle, Plus, Search, UserRound } from "lucide-react";
+
+import { useRecipientPickerQuery } from "@/features/recipients/queries";
+import type { RecipientListItemDto } from "@/features/recipients/types";
+import { numberToINR } from "@/common/utils";
+import { cn } from "@/lib/utils";
+
+import { CreateRecipientDialog } from "./create-recipient-dialog";
+
+export function RecipientPicker({
+  value,
+  initialRecipients,
+  error,
+  onChange,
+  onRecipientChange,
+  inputRef,
+}: {
+  value: string;
+  initialRecipients: RecipientListItemDto[];
+  error?: string;
+  onChange: (uuid: string) => void;
+  onRecipientChange?: (
+    recipient: Pick<RecipientListItemDto, "uuid" | "displayName"> | null,
+  ) => void;
+  inputRef?: Ref<HTMLInputElement>;
+}) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [selectedRecipient, setSelectedRecipient] = useState<Pick<
+    RecipientListItemDto,
+    "uuid" | "displayName"
+  > | null>(
+    initialRecipients.find((recipient) => recipient.uuid === value) ?? null,
+  );
+  const pickerQuery = useRecipientPickerQuery({
+    q: debouncedQuery,
+    initialData: initialRecipients,
+  });
+  const recipients = pickerQuery.data?.recipients ?? [];
+
+  useEffect(() => {
+    const timeout = window.setTimeout(
+      () => setDebouncedQuery(query.trim()),
+      250,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [query]);
+
+  useEffect(() => {
+    function handlePointerDown(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+    window.addEventListener("mousedown", handlePointerDown);
+    return () => window.removeEventListener("mousedown", handlePointerDown);
+  }, []);
+
+  function selectRecipient(
+    recipient: Pick<RecipientListItemDto, "uuid" | "displayName">,
+  ) {
+    setSelectedRecipient(recipient);
+    setQuery("");
+    setOpen(false);
+    onChange(recipient.uuid);
+    onRecipientChange?.(recipient);
+  }
+
+  function focusOption(index: number) {
+    if (recipients.length === 0) return;
+    const nextIndex = (index + recipients.length) % recipients.length;
+    optionRefs.current[nextIndex]?.focus();
+  }
+
+  return (
+    <>
+      <div ref={rootRef} className="relative">
+        <div
+          className={cn(
+            "flex min-h-11 items-center gap-2 rounded-[8px] border bg-background/18 px-3.5 focus-within:ring-2 focus-within:ring-ring",
+            error ? "border-destructive/65" : "border-input",
+          )}
+        >
+          <Search
+            className="h-4 w-4 shrink-0 text-secondary-foreground"
+            aria-hidden="true"
+          />
+          <input
+            ref={inputRef}
+            role="combobox"
+            aria-label="Recipient"
+            aria-expanded={open}
+            aria-controls="recipient-picker-list"
+            aria-invalid={Boolean(error)}
+            aria-describedby={error ? "recipient-picker-error" : undefined}
+            autoComplete="off"
+            value={open ? query : (selectedRecipient?.displayName ?? "")}
+            placeholder="Search recipients…"
+            onFocus={() => setOpen(true)}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setOpen(true);
+              if (selectedRecipient) {
+                setSelectedRecipient(null);
+                onChange("");
+                onRecipientChange?.(null);
+              }
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "ArrowDown" && recipients.length > 0) {
+                event.preventDefault();
+                setOpen(true);
+                window.requestAnimationFrame(() => focusOption(0));
+              }
+              if (event.key === "Escape") {
+                setOpen(false);
+              }
+            }}
+            className="min-h-11 w-full min-w-0 bg-transparent text-sm text-foreground outline-none placeholder:text-secondary-foreground/85"
+          />
+        </div>
+
+        {open ? (
+          <div
+            id="recipient-picker-list"
+            role="listbox"
+            className="absolute z-30 mt-2 max-h-80 w-full overflow-y-auto rounded-[8px] border border-border/70 bg-[linear-gradient(180deg,rgba(17,27,22,0.99),rgba(10,16,13,1))] p-1.5 shadow-[0_18px_38px_rgba(0,0,0,0.32)]"
+          >
+            {pickerQuery.isFetching ? (
+              <div
+                role="status"
+                className="flex items-center gap-2 px-3 py-3 text-sm text-secondary-foreground"
+              >
+                <LoaderCircle className="h-4 w-4 animate-spin" /> Searching…
+              </div>
+            ) : pickerQuery.isError ? (
+              <p role="alert" className="px-3 py-3 text-sm text-destructive">
+                Recipients are temporarily unavailable.
+              </p>
+            ) : recipients.length > 0 ? (
+              recipients.map((recipient, index) => (
+                <button
+                  key={recipient.uuid}
+                  ref={(element) => {
+                    optionRefs.current[index] = element;
+                  }}
+                  type="button"
+                  role="option"
+                  aria-selected={recipient.uuid === value}
+                  onClick={() => selectRecipient(recipient)}
+                  onKeyDown={(event) => {
+                    if (event.key === "ArrowDown") {
+                      event.preventDefault();
+                      focusOption(index + 1);
+                    } else if (event.key === "ArrowUp") {
+                      event.preventDefault();
+                      focusOption(index - 1);
+                    } else if (event.key === "Escape") {
+                      setOpen(false);
+                    }
+                  }}
+                  className="flex min-h-12 w-full items-center gap-3 rounded-[8px] px-3 py-2 text-left transition-colors hover:bg-secondary/18 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <UserRound
+                    className="h-4 w-4 shrink-0 text-primary"
+                    aria-hidden="true"
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-semibold text-foreground">
+                      {recipient.displayName}
+                    </span>
+                    <span className="block truncate text-xs text-secondary-foreground">
+                      {recipient.transactionCount} transactions ·{" "}
+                      {numberToINR(recipient.totalAmount)}
+                    </span>
+                  </span>
+                </button>
+              ))
+            ) : (
+              <p className="px-3 py-3 text-sm text-secondary-foreground">
+                No recipients found.
+              </p>
+            )}
+
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                setDialogOpen(true);
+              }}
+              className="mt-1 flex min-h-11 w-full items-center gap-2 rounded-[8px] border-t border-border/45 px-3 pt-2 text-sm font-semibold text-primary hover:bg-secondary/18 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Create New Recipient{query.trim() ? ` “${query.trim()}”` : ""}
+            </button>
+          </div>
+        ) : null}
+        {error ? (
+          <p
+            id="recipient-picker-error"
+            className="mt-1.5 text-sm text-destructive"
+          >
+            {error}
+          </p>
+        ) : null}
+      </div>
+
+      <CreateRecipientDialog
+        open={dialogOpen}
+        suggestedName={query.trim()}
+        onOpenChange={setDialogOpen}
+        onSelect={selectRecipient}
+      />
+    </>
+  );
+}

--- a/src/app/(app)/transactions/new/_components/transaction-create-model.test.ts
+++ b/src/app/(app)/transactions/new/_components/transaction-create-model.test.ts
@@ -1,0 +1,68 @@
+import {
+  getCreateTransactionDefaultValues,
+  mapCreateFormValuesToPayload,
+  transactionCreateFormSchema,
+} from "./transaction-create-model";
+
+describe("transaction create model", () => {
+  it("builds IST-aware defaults for the current time", () => {
+    expect(
+      getCreateTransactionDefaultValues(new Date("2026-07-12T15:12:00.000Z")),
+    ).toEqual({
+      amount: "",
+      recipientUuid: "",
+      categoryUuid: "",
+      subcategoryUuid: "",
+      type: "UPI",
+      timestamp: "2026-07-12T20:42",
+      reference: "",
+      accountLabel: "",
+      remarks: "",
+      locationRaw: "",
+    });
+  });
+
+  it("maps form values to the existing manual transaction API payload", () => {
+    expect(
+      mapCreateFormValuesToPayload({
+        amount: "250.50",
+        recipientUuid: "550e8400-e29b-41d4-a716-446655440000",
+        categoryUuid: "",
+        subcategoryUuid: "",
+        type: "UPI",
+        timestamp: "2026-07-12T20:42",
+        reference: "  UPI-123  ",
+        accountLabel: " ",
+        remarks: " Ride home ",
+        locationRaw: " ",
+      }),
+    ).toEqual({
+      amount: 250.5,
+      recipientUuid: "550e8400-e29b-41d4-a716-446655440000",
+      categoryUuid: null,
+      subcategoryUuid: null,
+      type: "UPI",
+      timestamp: "2026-07-12T15:12:00.000Z",
+      reference: "UPI-123",
+      accountLabel: null,
+      remarks: "Ride home",
+      locationRaw: null,
+    });
+  });
+
+  it("requires an amount, recipient, and valid timestamp", () => {
+    const result = transactionCreateFormSchema.safeParse({
+      ...getCreateTransactionDefaultValues(
+        new Date("2026-07-12T15:12:00.000Z"),
+      ),
+      timestamp: "not-a-date",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.map((issue) => issue.path[0])).toEqual(
+        expect.arrayContaining(["amount", "recipientUuid", "timestamp"]),
+      );
+    }
+  });
+});

--- a/src/app/(app)/transactions/new/_components/transaction-create-model.ts
+++ b/src/app/(app)/transactions/new/_components/transaction-create-model.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+
+import type { TransactionCreateInput } from "@/features/transactions/types";
+import {
+  formatDateTimeLocalValue,
+  parseDateTimeLocalAsIst,
+} from "@/app/(app)/transactions/[id]/_components/transaction-detail-model";
+
+export const transactionCreateFormSchema = z.object({
+  amount: z
+    .string()
+    .trim()
+    .min(1, "Amount is required")
+    .refine((value) => Number.isFinite(Number(value)) && Number(value) > 0, {
+      message: "Enter an amount greater than 0",
+    }),
+  recipientUuid: z.string().uuid("Select a recipient"),
+  categoryUuid: z.string(),
+  subcategoryUuid: z.string(),
+  type: z.enum(["UPI", "CARD", "CASH", "NETBANKING", "OTHER"]),
+  timestamp: z
+    .string()
+    .trim()
+    .min(1, "Date and time are required")
+    .refine(
+      (value) => !Number.isNaN(parseDateTimeLocalAsIst(value).getTime()),
+      {
+        message: "Enter a valid date and time",
+      },
+    ),
+  reference: z.string().trim(),
+  accountLabel: z.string().trim(),
+  remarks: z.string().trim(),
+  locationRaw: z.string().trim(),
+});
+
+export type TransactionCreateFormSchema = z.infer<
+  typeof transactionCreateFormSchema
+>;
+
+export function getCreateTransactionDefaultValues(
+  now = new Date(),
+): TransactionCreateFormSchema {
+  return {
+    amount: "",
+    recipientUuid: "",
+    categoryUuid: "",
+    subcategoryUuid: "",
+    type: "UPI",
+    timestamp: formatDateTimeLocalValue(now.toISOString()),
+    reference: "",
+    accountLabel: "",
+    remarks: "",
+    locationRaw: "",
+  };
+}
+
+export function mapCreateFormValuesToPayload(
+  values: TransactionCreateFormSchema,
+): TransactionCreateInput {
+  return {
+    amount: Number(values.amount),
+    recipientUuid: values.recipientUuid,
+    categoryUuid: toNullableValue(values.categoryUuid),
+    subcategoryUuid: toNullableValue(values.subcategoryUuid),
+    type: values.type,
+    timestamp: parseDateTimeLocalAsIst(values.timestamp).toISOString(),
+    reference: toNullableValue(values.reference),
+    accountLabel: toNullableValue(values.accountLabel),
+    remarks: toNullableValue(values.remarks),
+    locationRaw: toNullableValue(values.locationRaw),
+  };
+}
+
+function toNullableValue(value: string) {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}

--- a/src/app/(app)/transactions/new/_components/transaction-create-page-view.tsx
+++ b/src/app/(app)/transactions/new/_components/transaction-create-page-view.tsx
@@ -1,0 +1,579 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState, type ReactNode } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  ArrowLeft,
+  ChevronDown,
+  LoaderCircle,
+  Plus,
+  ReceiptText,
+} from "lucide-react";
+import { Controller, useForm } from "react-hook-form";
+import { useRouter } from "next/navigation";
+
+import {
+  formatTransactionAmount,
+  formatTransactionDateTime,
+  getSubcategoryOptions,
+  isValidSubcategorySelection,
+  parseDateTimeLocalAsIst,
+} from "@/app/(app)/transactions/[id]/_components/transaction-detail-model";
+import { dashboardPanelClassName } from "@/app/(app)/dashboard/_components/dashboard-style";
+import { AppPageHeader } from "@/components/product/app-page-header";
+import {
+  MobileActionBar,
+  MobilePageHeader,
+} from "@/components/product/mobile/mobile-primitives";
+import { Button } from "@/components/ui/button";
+import { Select } from "@/components/ui/select";
+import { toast } from "@/components/ui/sonner";
+import { useCategoriesQuery } from "@/features/categories/queries";
+import { useCreateTransactionMutation } from "@/features/transactions/mutations";
+import type { TransactionCreatePageInitialData } from "@/features/transactions/types";
+import { ApiClientError, getApiClientErrorMessage } from "@/lib/api/client";
+import { cn } from "@/lib/utils";
+
+import { RecipientPicker } from "./recipient-picker";
+import {
+  getCreateTransactionDefaultValues,
+  mapCreateFormValuesToPayload,
+  transactionCreateFormSchema,
+  type TransactionCreateFormSchema,
+} from "./transaction-create-model";
+
+const fieldClassName =
+  "min-h-11 w-full rounded-[8px] border border-input bg-background/18 px-3.5 text-sm text-foreground outline-none transition-colors placeholder:text-secondary-foreground/85 focus-visible:ring-2 focus-visible:ring-ring";
+const textAreaClassName = `${fieldClassName} min-h-[112px] py-3`;
+
+export function TransactionCreatePageView({
+  initialCategoriesData,
+  initialRecipientsData,
+}: TransactionCreatePageInitialData) {
+  const router = useRouter();
+  const categoriesQuery = useCategoriesQuery({
+    initialData: initialCategoriesData,
+  });
+  const createMutation = useCreateTransactionMutation();
+  const [banner, setBanner] = useState<string | null>(null);
+  const [moreDetailsOpen, setMoreDetailsOpen] = useState(false);
+  const [selectedRecipient, setSelectedRecipient] = useState<{
+    uuid: string;
+    displayName: string;
+  } | null>(null);
+  const categories = categoriesQuery.data ?? initialCategoriesData;
+  const form = useForm<TransactionCreateFormSchema>({
+    resolver: zodResolver(transactionCreateFormSchema),
+    defaultValues: getCreateTransactionDefaultValues(),
+  });
+
+  const amount = form.watch("amount");
+  const categoryUuid = form.watch("categoryUuid");
+  const subcategoryUuid = form.watch("subcategoryUuid");
+  const transactionType = form.watch("type");
+  const timestamp = form.watch("timestamp");
+  const subcategories = getSubcategoryOptions(categories, categoryUuid);
+  const selectedCategory = categories.find(
+    (item) => item.uuid === categoryUuid,
+  );
+  const selectedSubcategory = subcategories.find(
+    (item) => item.uuid === subcategoryUuid,
+  );
+
+  useEffect(() => {
+    if (
+      !isValidSubcategorySelection(categories, categoryUuid, subcategoryUuid)
+    ) {
+      form.setValue("subcategoryUuid", "", { shouldDirty: true });
+    }
+  }, [categories, categoryUuid, form, subcategoryUuid]);
+
+  useEffect(() => {
+    function warnOnUnload(event: BeforeUnloadEvent) {
+      if (!form.formState.isDirty) return;
+      event.preventDefault();
+    }
+    window.addEventListener("beforeunload", warnOnUnload);
+    return () => window.removeEventListener("beforeunload", warnOnUnload);
+  }, [form.formState.isDirty]);
+
+  function canLeave() {
+    return (
+      !form.formState.isDirty ||
+      window.confirm("Discard this unsaved transaction?")
+    );
+  }
+
+  async function handleSubmit(values: TransactionCreateFormSchema) {
+    setBanner(null);
+    form.clearErrors();
+
+    try {
+      const created = await createMutation.mutateAsync(
+        mapCreateFormValuesToPayload(values),
+      );
+      toast({
+        tone: "success",
+        title: "Transaction created",
+        description: "The manual transaction was added to your workspace.",
+        durationMs: 3200,
+      });
+      router.push(`/transactions/${created.uuid}`);
+    } catch (error) {
+      applyServerErrors(error, form.setError);
+      setBanner(
+        getApiClientErrorMessage(
+          error,
+          "Unable to create this transaction right now.",
+        ),
+      );
+    }
+  }
+
+  const parsedTimestamp = parseDateTimeLocalAsIst(timestamp);
+  const summaryTimestamp = Number.isNaN(parsedTimestamp.getTime())
+    ? null
+    : parsedTimestamp.toISOString();
+
+  return (
+    <form
+      onSubmit={form.handleSubmit(handleSubmit)}
+      className="space-y-3.5 pb-2"
+    >
+      <MobilePageHeader
+        eyebrow="Transaction workspace"
+        title="Add Transaction"
+        description="Record a payment that was not captured automatically."
+        actions={
+          <Button asChild variant="secondary" className="w-full">
+            <Link
+              href="/transactions"
+              onClick={(event) => !canLeave() && event.preventDefault()}
+            >
+              <ArrowLeft className="h-4 w-4" /> Back to Transactions
+            </Link>
+          </Button>
+        }
+      />
+      <div className="hidden lg:block">
+        <AppPageHeader
+          eyebrow="Transaction workspace"
+          title="Add Transaction"
+          description="Record a payment that was not captured from SMS or an automatic import."
+          meta={
+            <span className="inline-flex min-h-8 items-center rounded-[999px] border border-primary/25 bg-primary/10 px-3 text-xs font-semibold text-primary">
+              Manual entry
+            </span>
+          }
+          actions={
+            <div className="flex flex-wrap gap-2">
+              <Button asChild variant="secondary">
+                <Link
+                  href="/transactions"
+                  onClick={(event) => !canLeave() && event.preventDefault()}
+                >
+                  <ArrowLeft className="h-4 w-4" /> Back to Transactions
+                </Link>
+              </Button>
+              <Button type="submit" disabled={createMutation.isPending}>
+                {createMutation.isPending ? (
+                  <LoaderCircle className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Plus className="h-4 w-4" />
+                )}
+                {createMutation.isPending ? "Creating…" : "Create Transaction"}
+              </Button>
+            </div>
+          }
+        />
+      </div>
+
+      {banner ? (
+        <section
+          role="alert"
+          className="rounded-[8px] border border-destructive/45 bg-destructive/10 px-4 py-3 text-sm text-foreground"
+        >
+          {banner}
+        </section>
+      ) : null}
+
+      <div className="grid gap-3 2xl:grid-cols-[minmax(0,1.6fr)_minmax(300px,0.72fr)]">
+        <div className="space-y-3">
+          <section
+            className={cn(dashboardPanelClassName, "overflow-visible p-5")}
+          >
+            <SectionHeading number="1" title="Payment" />
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              <Field
+                label="Amount"
+                error={form.formState.errors.amount?.message}
+              >
+                <div className="flex min-h-11 items-center rounded-[8px] border border-input bg-background/18 focus-within:ring-2 focus-within:ring-ring">
+                  <span className="border-r border-border/50 px-3.5 text-sm text-secondary-foreground">
+                    ₹
+                  </span>
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    inputMode="decimal"
+                    autoComplete="off"
+                    className="min-h-11 w-full min-w-0 bg-transparent px-3.5 text-sm text-foreground outline-none"
+                    {...form.register("amount")}
+                  />
+                </div>
+              </Field>
+              <Field label="Type" error={form.formState.errors.type?.message}>
+                <Controller
+                  control={form.control}
+                  name="type"
+                  render={({ field }) => (
+                    <Select
+                      ariaLabel="Transaction type"
+                      value={field.value}
+                      onValueChange={field.onChange}
+                      options={[
+                        { value: "UPI", label: "UPI" },
+                        { value: "CARD", label: "Card" },
+                        { value: "CASH", label: "Cash" },
+                        { value: "NETBANKING", label: "Net banking" },
+                        { value: "OTHER", label: "Other" },
+                      ]}
+                    />
+                  )}
+                />
+              </Field>
+              <div className="min-w-0 text-sm font-medium text-foreground md:col-span-2">
+                <span>Recipient</span>
+                <div className="mt-2">
+                  <Controller
+                    control={form.control}
+                    name="recipientUuid"
+                    render={({ field }) => (
+                      <RecipientPicker
+                        value={field.value}
+                        initialRecipients={initialRecipientsData}
+                        error={form.formState.errors.recipientUuid?.message}
+                        onChange={field.onChange}
+                        onRecipientChange={setSelectedRecipient}
+                        inputRef={field.ref}
+                      />
+                    )}
+                  />
+                </div>
+              </div>
+              <Field
+                label="Date and time"
+                error={form.formState.errors.timestamp?.message}
+                className="md:col-span-2"
+              >
+                <input
+                  type="datetime-local"
+                  autoComplete="off"
+                  className={fieldClassName}
+                  {...form.register("timestamp")}
+                />
+              </Field>
+            </div>
+          </section>
+
+          <section
+            className={cn(dashboardPanelClassName, "overflow-visible p-5")}
+          >
+            <SectionHeading number="2" title="Classification" optional />
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              <Field
+                label="Category"
+                error={form.formState.errors.categoryUuid?.message}
+              >
+                <Controller
+                  control={form.control}
+                  name="categoryUuid"
+                  render={({ field }) => (
+                    <Select
+                      ariaLabel="Category"
+                      value={field.value}
+                      onValueChange={field.onChange}
+                      options={[
+                        { value: "", label: "Uncategorized" },
+                        ...categories.map((category) => ({
+                          value: category.uuid,
+                          label: category.name,
+                        })),
+                      ]}
+                    />
+                  )}
+                />
+              </Field>
+              <Field
+                label="Subcategory"
+                error={form.formState.errors.subcategoryUuid?.message}
+              >
+                <Controller
+                  control={form.control}
+                  name="subcategoryUuid"
+                  render={({ field }) => (
+                    <Select
+                      ariaLabel="Subcategory"
+                      value={field.value}
+                      onValueChange={field.onChange}
+                      disabled={!categoryUuid || subcategories.length === 0}
+                      options={[
+                        {
+                          value: "",
+                          label: categoryUuid
+                            ? "No subcategory"
+                            : "Choose a category first",
+                        },
+                        ...subcategories.map((subcategory) => ({
+                          value: subcategory.uuid,
+                          label: subcategory.name,
+                        })),
+                      ]}
+                    />
+                  )}
+                />
+              </Field>
+            </div>
+          </section>
+
+          <section className={cn(dashboardPanelClassName, "p-5")}>
+            <button
+              type="button"
+              className="flex min-h-11 w-full items-center justify-between text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring lg:pointer-events-none lg:min-h-0"
+              aria-expanded={moreDetailsOpen}
+              onClick={() => setMoreDetailsOpen((open) => !open)}
+            >
+              <SectionHeading number="3" title="More Details" optional />
+              <ChevronDown
+                className={cn(
+                  "h-4 w-4 transition-transform lg:hidden",
+                  moreDetailsOpen && "rotate-180",
+                )}
+              />
+            </button>
+            <div
+              className={cn(
+                "mt-4 gap-4 md:grid-cols-2",
+                moreDetailsOpen ? "grid" : "hidden lg:grid",
+              )}
+            >
+              <Field
+                label="Account label"
+                error={form.formState.errors.accountLabel?.message}
+              >
+                <input
+                  autoComplete="off"
+                  className={fieldClassName}
+                  {...form.register("accountLabel")}
+                />
+              </Field>
+              <Field
+                label="Reference"
+                error={form.formState.errors.reference?.message}
+              >
+                <input
+                  autoComplete="off"
+                  className={fieldClassName}
+                  {...form.register("reference")}
+                />
+              </Field>
+              <Field
+                label="Location"
+                error={form.formState.errors.locationRaw?.message}
+                className="md:col-span-2"
+              >
+                <input
+                  autoComplete="off"
+                  className={fieldClassName}
+                  {...form.register("locationRaw")}
+                />
+              </Field>
+              <Field
+                label="Remarks"
+                error={form.formState.errors.remarks?.message}
+                className="md:col-span-2"
+              >
+                <textarea
+                  className={textAreaClassName}
+                  {...form.register("remarks")}
+                />
+              </Field>
+            </div>
+          </section>
+
+          <div className="hidden justify-end gap-2 lg:flex">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => canLeave() && router.push("/transactions")}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={createMutation.isPending}>
+              {createMutation.isPending ? (
+                <LoaderCircle className="h-4 w-4 animate-spin" />
+              ) : (
+                <Plus className="h-4 w-4" />
+              )}
+              {createMutation.isPending ? "Creating…" : "Create Transaction"}
+            </Button>
+          </div>
+        </div>
+
+        <aside
+          className={cn(dashboardPanelClassName, "hidden h-fit p-5 2xl:block")}
+        >
+          <div className="flex items-center gap-2">
+            <ReceiptText className="h-4 w-4 text-primary" aria-hidden="true" />
+            <h2 className="text-base font-semibold text-foreground">
+              Transaction Summary
+            </h2>
+          </div>
+          <p className="mt-5 text-3xl font-semibold tabular-nums text-foreground">
+            {Number(amount) > 0
+              ? formatTransactionAmount(Number(amount))
+              : "₹0.00"}
+          </p>
+          <dl className="mt-5 space-y-4 text-sm">
+            <SummaryItem
+              label="Recipient"
+              value={selectedRecipient?.displayName ?? "Not selected"}
+            />
+            <SummaryItem label="Type" value={transactionType} />
+            <SummaryItem
+              label="Classification"
+              value={
+                [selectedCategory?.name, selectedSubcategory?.name]
+                  .filter(Boolean)
+                  .join(" · ") || "Uncategorized"
+              }
+            />
+            <SummaryItem
+              label="When"
+              value={
+                summaryTimestamp
+                  ? formatTransactionDateTime(summaryTimestamp)
+                  : "Invalid date"
+              }
+            />
+            <SummaryItem label="Source" value="Manual entry" />
+          </dl>
+        </aside>
+      </div>
+
+      <MobileActionBar>
+        <Button
+          type="submit"
+          className="w-full"
+          disabled={createMutation.isPending}
+        >
+          {createMutation.isPending ? (
+            <LoaderCircle className="h-4 w-4 animate-spin" />
+          ) : (
+            <Plus className="h-4 w-4" />
+          )}
+          {createMutation.isPending ? "Creating…" : "Create Transaction"}
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          className="w-full"
+          onClick={() => canLeave() && router.push("/transactions")}
+        >
+          Cancel
+        </Button>
+      </MobileActionBar>
+    </form>
+  );
+}
+
+function Field({
+  label,
+  error,
+  className,
+  children,
+}: {
+  label: string;
+  error?: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <label
+      className={cn(
+        "block min-w-0 text-sm font-medium text-foreground",
+        className,
+      )}
+    >
+      {label}
+      <div className="mt-2">{children}</div>
+      {error ? (
+        <span className="mt-1.5 block text-sm text-destructive">{error}</span>
+      ) : null}
+    </label>
+  );
+}
+
+function SectionHeading({
+  number,
+  title,
+  optional = false,
+}: {
+  number: string;
+  title: string;
+  optional?: boolean;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <h2 className="text-[1.05rem] font-semibold text-foreground">
+        {number}. {title}
+      </h2>
+      {optional ? (
+        <span className="text-xs font-medium text-secondary-foreground">
+          Optional
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function SummaryItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="border-t border-border/35 pt-3 first:border-0 first:pt-0">
+      <dt className="text-secondary-foreground">{label}</dt>
+      <dd className="mt-1 break-words font-medium text-foreground">{value}</dd>
+    </div>
+  );
+}
+
+function applyServerErrors(
+  error: unknown,
+  setError: ReturnType<typeof useForm<TransactionCreateFormSchema>>["setError"],
+) {
+  if (!(error instanceof ApiClientError) || !Array.isArray(error.body?.issues))
+    return;
+  const fields = new Set(Object.keys(transactionCreateFormSchema.shape));
+  for (const issue of error.body.issues) {
+    if (
+      !issue ||
+      typeof issue !== "object" ||
+      !("path" in issue) ||
+      !("message" in issue)
+    )
+      continue;
+    const field = Array.isArray(issue.path) ? issue.path[0] : null;
+    if (
+      typeof field === "string" &&
+      fields.has(field) &&
+      typeof issue.message === "string"
+    ) {
+      setError(
+        field as keyof TransactionCreateFormSchema,
+        { type: "server", message: issue.message },
+        { shouldFocus: true },
+      );
+    }
+  }
+}

--- a/src/app/(app)/transactions/new/loading.tsx
+++ b/src/app/(app)/transactions/new/loading.tsx
@@ -1,0 +1,42 @@
+import {
+  AppPageHeaderSkeleton,
+  MobilePageHeaderSkeleton,
+} from "@/components/product/page-loading-skeletons";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function TransactionCreateLoading() {
+  return (
+    <div className="space-y-3.5">
+      <MobilePageHeaderSkeleton
+        titleWidth="w-52"
+        descriptionWidth="w-[18rem]"
+      />
+      <div className="hidden lg:block">
+        <AppPageHeaderSkeleton
+          eyebrowWidth="w-44"
+          titleWidth="w-72"
+          descriptionWidth="w-[34rem]"
+          actionWidths={["w-44", "w-44"]}
+        />
+      </div>
+      <div className="grid gap-3 2xl:grid-cols-[minmax(0,1.6fr)_minmax(300px,0.72fr)]">
+        <div className="space-y-3">
+          {[3, 2, 4].map((count, section) => (
+            <section
+              key={section}
+              className="rounded-[8px] border border-border/55 bg-background/12 p-5"
+            >
+              <Skeleton className="h-6 w-40 rounded-[8px]" />
+              <div className="mt-4 grid gap-4 md:grid-cols-2">
+                {Array.from({ length: count }).map((_, index) => (
+                  <Skeleton key={index} className="h-16 rounded-[8px]" />
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+        <Skeleton className="hidden h-64 rounded-[8px] 2xl:block" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/transactions/new/page.tsx
+++ b/src/app/(app)/transactions/new/page.tsx
@@ -1,0 +1,8 @@
+import { getTransactionCreatePageData } from "@/server/page-data/transaction-create-page-data";
+
+import { TransactionCreatePageView } from "./_components/transaction-create-page-view";
+
+export default async function TransactionCreatePage() {
+  const data = await getTransactionCreatePageData();
+  return <TransactionCreatePageView {...data} />;
+}

--- a/src/app/api/recipients/route.ts
+++ b/src/app/api/recipients/route.ts
@@ -1,4 +1,8 @@
 import { withRouteLogging } from "@/server/api/logging";
-import { getRecipients as getRecipientsHandler } from "@/server/modules/recipients/controller";
+import {
+  getRecipients as getRecipientsHandler,
+  postRecipient as postRecipientHandler,
+} from "@/server/modules/recipients/controller";
 
 export const GET = withRouteLogging(getRecipientsHandler);
+export const POST = withRouteLogging(postRecipientHandler);

--- a/src/features/recipients/mutations.ts
+++ b/src/features/recipients/mutations.ts
@@ -10,8 +10,21 @@ import { recipientsQueryKeys } from "./query-keys";
 import type {
   RecipientAliasTransferImpact,
   RecipientAliasWriteDto,
+  RecipientCreateDto,
   RecipientListItemDto,
 } from "./types";
+
+export function useCreateRecipientMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: { displayName: string }) =>
+      apiPost<RecipientCreateDto>("/api/recipients", input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: recipientsQueryKeys.all });
+    },
+  });
+}
 
 export type AddRecipientAliasInput = {
   recipientUuid: string;

--- a/src/features/recipients/queries.ts
+++ b/src/features/recipients/queries.ts
@@ -11,10 +11,47 @@ import {
 } from "./query-state";
 import { recipientsQueryKeys } from "./query-keys";
 import type {
+  RecipientListItemDto,
   RecipientListResponse,
   RecipientsApiQuery,
   RecipientsQueryResult,
 } from "./types";
+
+const recipientPickerQuery = {
+  page: 1,
+  pageSize: 10,
+  sortBy: "transactionCount" as const,
+  sortOrder: "desc" as const,
+};
+
+export function useRecipientPickerQuery(input: {
+  q: string;
+  initialData: RecipientListItemDto[];
+}) {
+  const query = { ...recipientPickerQuery, q: input.q };
+
+  return useQuery({
+    queryKey: recipientsQueryKeys.list(query),
+    queryFn: () => getRecipientsQueryData(query),
+    initialData:
+      input.q === ""
+        ? {
+            status: "ready" as const,
+            message: null,
+            recipients: input.initialData,
+            pagination: {
+              page: 1,
+              pageSize: 10,
+              total: input.initialData.length,
+              totalPages: input.initialData.length > 0 ? 1 : 0,
+              hasNext: false,
+              hasPrev: false,
+            },
+          }
+        : undefined,
+    staleTime: 30_000,
+  });
+}
 
 export async function getRecipientsQueryData(
   query: RecipientsApiQuery

--- a/src/features/recipients/types.ts
+++ b/src/features/recipients/types.ts
@@ -16,6 +16,15 @@ export type RecipientListItemDto = {
   aliases: RecipientAliasDto[];
 };
 
+export type RecipientCreateDto = Pick<
+  RecipientListItemDto,
+  "uuid" | "displayName" | "normalizedName"
+>;
+
+export type RecipientCreateConflict = {
+  existingRecipient: Pick<RecipientListItemDto, "uuid" | "displayName">;
+};
+
 export type RecipientAliasTransferImpact = {
   sourceRecipient: {
     uuid: string;

--- a/src/features/transactions/types.ts
+++ b/src/features/transactions/types.ts
@@ -92,6 +92,11 @@ export type TransactionDetailPageInitialData = {
   initialCategoriesData: CategoryOption[];
 };
 
+export type TransactionCreatePageInitialData = {
+  initialCategoriesData: CategoryOption[];
+  initialRecipientsData: import("@/features/recipients/types").RecipientListItemDto[];
+};
+
 export type TransactionCreateInput = {
   amount: number;
   recipientUuid: string;
@@ -139,3 +144,6 @@ export type TransactionDetailFormValues = {
   locationRaw: string;
 };
 
+export type TransactionCreateFormValues = TransactionDetailFormValues & {
+  recipientUuid: string;
+};

--- a/src/server/api/responses.ts
+++ b/src/server/api/responses.ts
@@ -19,7 +19,7 @@ export function fromServiceError(result: ServiceFailure) {
     case "NOT_FOUND":
       return jsonError("Not found", 404);
     case "CONFLICT":
-      return jsonError("Conflict", 409);
+      return jsonError("Conflict", 409, result.details ? { details: result.details } : undefined);
     case "UNPROCESSABLE":
       return jsonError("Unprocessable entity", 422, result.details ? { details: result.details } : undefined);
     default:

--- a/src/server/modules/recipients/controller.test.ts
+++ b/src/server/modules/recipients/controller.test.ts
@@ -4,18 +4,20 @@ jest.mock("@/server/auth/session", () => ({
 
 jest.mock("./service", () => ({
   addRecipientIdentifier: jest.fn(),
+  createRecipient: jest.fn(),
   getRecipient: jest.fn(),
   listRecipients: jest.fn(),
 }));
 
 import { requireSessionUser } from "@/server/auth/session";
 
-import { getRecipientById, getRecipients } from "./controller";
-import { getRecipient, listRecipients } from "./service";
+import { getRecipientById, getRecipients, postRecipient } from "./controller";
+import { createRecipient, getRecipient, listRecipients } from "./service";
 
 const requireSessionUserMock = jest.mocked(requireSessionUser);
 const getRecipientMock = jest.mocked(getRecipient);
 const listRecipientsMock = jest.mocked(listRecipients);
+const createRecipientMock = jest.mocked(createRecipient);
 
 describe("recipients controller", () => {
   beforeEach(() => {
@@ -75,6 +77,55 @@ describe("recipients controller", () => {
     await expect(response.json()).resolves.toMatchObject({
       message: "Invalid request",
       issues: expect.any(Array),
+    });
+  });
+
+  it("creates a recipient for the authenticated user", async () => {
+    createRecipientMock.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        uuid: "rcp-7",
+        displayName: "Uber India",
+        normalizedName: "uber india",
+      },
+    });
+
+    const response = await postRecipient(
+      new Request("http://localhost/api/recipients", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ displayName: "Uber India" }),
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect(createRecipientMock).toHaveBeenCalledWith({
+      userUuid: "user-1",
+      displayName: "Uber India",
+    });
+  });
+
+  it("returns matching recipient details on create conflict", async () => {
+    createRecipientMock.mockResolvedValueOnce({
+      ok: false,
+      error: "CONFLICT",
+      details: {
+        existingRecipient: { uuid: "rcp-7", displayName: "Uber India" },
+      },
+    });
+
+    const response = await postRecipient(
+      new Request("http://localhost/api/recipients", {
+        method: "POST",
+        body: JSON.stringify({ displayName: "Uber India" }),
+      })
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      details: {
+        existingRecipient: { uuid: "rcp-7", displayName: "Uber India" },
+      },
     });
   });
 

--- a/src/server/modules/recipients/controller.ts
+++ b/src/server/modules/recipients/controller.ts
@@ -4,11 +4,18 @@ import { requireSessionUser } from "@/server/auth/session";
 
 import {
   addRecipientAliasSchema,
+  createRecipientSchema,
   listRecipientsQuerySchema,
   recipientIdParamsSchema,
   updateRecipientSchema,
 } from "./schemas";
-import { addRecipientAlias, getRecipient, listRecipients, updateRecipient } from "./service";
+import {
+  addRecipientAlias,
+  createRecipient,
+  getRecipient,
+  listRecipients,
+  updateRecipient,
+} from "./service";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -63,6 +70,32 @@ export async function getRecipients(request: Request) {
   });
   const data = unwrapOrResponse(result);
   return data instanceof Response ? data : jsonOk(data);
+}
+
+export async function postRecipient(request: Request) {
+  const path = new URL(request.url).pathname;
+  const sessionData = await requireUserUuid();
+  if (sessionData instanceof Response) {
+    return sessionData;
+  }
+
+  const json = await parseJsonBody(request);
+  if (json instanceof Response) {
+    return json;
+  }
+
+  const parsed = createRecipientSchema.safeParse(json);
+  if (!parsed.success) {
+    logValidationFailure(path, parsed.error.issues);
+    return jsonError("Invalid request", 400, { issues: parsed.error.issues });
+  }
+
+  const result = await createRecipient({
+    userUuid: sessionData.userUuid,
+    displayName: parsed.data.displayName,
+  });
+  const data = unwrapOrResponse(result);
+  return data instanceof Response ? data : jsonOk(data, 201);
 }
 
 export async function getRecipientById(

--- a/src/server/modules/recipients/schemas.ts
+++ b/src/server/modules/recipients/schemas.ts
@@ -18,6 +18,8 @@ export const updateRecipientSchema = z.object({
   displayName: z.string().trim().min(1).max(200),
 });
 
+export const createRecipientSchema = updateRecipientSchema;
+
 export const aliasTypeSchema = z.union([
   z.enum([
     RecipientIdentifierKind.UPI_ID,

--- a/src/server/modules/recipients/service.test.ts
+++ b/src/server/modules/recipients/service.test.ts
@@ -7,6 +7,7 @@ jest.mock("@/lib/prisma-rewrite", () => ({
       findFirst: jest.fn(),
       findMany: jest.fn(),
     },
+    $transaction: jest.fn(),
     transaction: {
       groupBy: jest.fn(),
     },
@@ -19,7 +20,7 @@ jest.mock("@/lib/prisma-rewrite", () => ({
 
 import { RecipientIdentifierKind } from "@/generated/prisma-rewrite";
 
-import { listRecipients } from "./service";
+import { createRecipient, listRecipients } from "./service";
 
 const mockPrisma = (globalThis as any).__recipientsPrismaMock;
 
@@ -47,6 +48,61 @@ describe("recipient service", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockPrisma.transaction.groupBy.mockResolvedValue([]);
+    mockPrisma.$transaction.mockImplementation(async (callback: (client: unknown) => unknown) =>
+      callback(mockPrisma)
+    );
+  });
+
+  it("creates a searchable recipient with a text identifier", async () => {
+    mockPrisma.recipient.findFirst.mockResolvedValueOnce(null);
+    mockPrisma.recipient.create.mockResolvedValueOnce({
+      id: 7,
+      uuid: "rcp-7",
+      displayName: "Uber India",
+      normalizedName: "uber india",
+    });
+    mockPrisma.recipientIdentifier.create.mockResolvedValueOnce({ id: 17 });
+
+    await expect(
+      createRecipient({ userUuid: "user-1", displayName: "  Uber   India  " })
+    ).resolves.toEqual({
+      ok: true,
+      data: {
+        uuid: "rcp-7",
+        displayName: "Uber India",
+        normalizedName: "uber india",
+      },
+    });
+    expect(mockPrisma.recipientIdentifier.create).toHaveBeenCalledWith({
+      data: {
+        userUuid: "user-1",
+        recipientId: 7,
+        kind: RecipientIdentifierKind.TEXT,
+        value: "Uber India",
+        normalizedValue: "uber india",
+      },
+    });
+  });
+
+  it("returns the matching recipient when a normalized name already exists", async () => {
+    mockPrisma.recipient.findFirst.mockResolvedValueOnce({
+      uuid: "rcp-existing",
+      displayName: "Uber India",
+    });
+
+    await expect(
+      createRecipient({ userUuid: "user-1", displayName: " uber india " })
+    ).resolves.toEqual({
+      ok: false,
+      error: "CONFLICT",
+      details: {
+        existingRecipient: {
+          uuid: "rcp-existing",
+          displayName: "Uber India",
+        },
+      },
+    });
+    expect(mockPrisma.recipient.create).not.toHaveBeenCalled();
   });
 
   it("filters by recipient and identifier fields, paginates, and sorts by display name", async () => {

--- a/src/server/modules/recipients/service.ts
+++ b/src/server/modules/recipients/service.ts
@@ -12,6 +12,8 @@ import type {
   RecipientAliasWriteResult,
   RecipientListInput,
   RecipientListResult,
+  RecipientCreateInput,
+  RecipientCreateResult,
   RecipientLookupInput,
   RecipientUpdateInput,
   RecipientUpdateResult,
@@ -121,6 +123,88 @@ function toRecipientDetailDto(record: {
 
 function normalizeValue(value: string) {
   return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function normalizeDisplayName(value: string) {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+async function findRecipientNameConflict(userUuid: string, normalizedName: string) {
+  return prisma.recipient.findFirst({
+    where: { userUuid, normalizedName },
+    select: { uuid: true, displayName: true },
+  });
+}
+
+export async function createRecipient(
+  input: RecipientCreateInput
+): Promise<RecipientCreateResult> {
+  const displayName = normalizeDisplayName(input.displayName);
+  const normalizedName = normalizeValue(displayName);
+
+  try {
+    const duplicate = await findRecipientNameConflict(input.userUuid, normalizedName);
+    if (duplicate) {
+      return fail("CONFLICT", { existingRecipient: duplicate });
+    }
+
+    const recipient = await prisma.$transaction(async (transaction) => {
+      const created = await transaction.recipient.create({
+        data: {
+          userUuid: input.userUuid,
+          displayName,
+          normalizedName,
+        },
+        select: {
+          id: true,
+          uuid: true,
+          displayName: true,
+          normalizedName: true,
+        },
+      });
+
+      await transaction.recipientIdentifier.create({
+        data: {
+          userUuid: input.userUuid,
+          recipientId: created.id,
+          kind: RecipientIdentifierKind.TEXT,
+          value: displayName,
+          normalizedValue: normalizedName,
+        },
+      });
+
+      return created;
+    });
+
+    logger.info({
+      event: "recipient.created",
+      userId: input.userUuid,
+      recipientId: recipient.id,
+    });
+
+    return ok({
+      uuid: recipient.uuid,
+      displayName: recipient.displayName,
+      normalizedName: recipient.normalizedName,
+    });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      const duplicate = await findRecipientNameConflict(input.userUuid, normalizedName);
+      if (duplicate) {
+        return fail("CONFLICT", { existingRecipient: duplicate });
+      }
+    }
+
+    logger.error(
+      {
+        event: "recipient.create.db_failed",
+        userId: input.userUuid,
+        message: "Failed to create recipient",
+      },
+      error
+    );
+    return fail("INTERNAL_ERROR");
+  }
 }
 
 function buildNonEmptyRecipientWhere(userUuid: string) {

--- a/src/server/modules/recipients/types.ts
+++ b/src/server/modules/recipients/types.ts
@@ -73,6 +73,17 @@ export type RecipientUpdateInput = RecipientLookupInput & {
   displayName: string;
 };
 
+export type RecipientCreateInput = {
+  userUuid: string;
+  displayName: string;
+};
+
+export type RecipientCreateDto = {
+  uuid: string;
+  displayName: string;
+  normalizedName: string;
+};
+
 export type RecipientAliasWriteInput = RecipientLookupInput & {
   value: string;
   aliasType?: RecipientAliasType | "AUTO";
@@ -121,6 +132,10 @@ export type RecipientListInput = {
 };
 
 export type RecipientListResult = ServiceResult<RecipientListDto, "INTERNAL_ERROR">;
+export type RecipientCreateResult = ServiceResult<
+  RecipientCreateDto,
+  "CONFLICT" | "INTERNAL_ERROR"
+>;
 export type RecipientUpdateResult = ServiceResult<
   RecipientDto,
   "NOT_FOUND" | "CONFLICT" | "INTERNAL_ERROR"

--- a/src/server/modules/transactions/controller.test.ts
+++ b/src/server/modules/transactions/controller.test.ts
@@ -3,18 +3,20 @@ jest.mock("@/server/auth/session", () => ({
 }));
 
 jest.mock("./service", () => ({
+  createTransaction: jest.fn(),
   listTransactions: jest.fn(),
   updateTransactionCategory: jest.fn(),
 }));
 
 import { requireSessionUser } from "@/server/auth/session";
 
-import { getTransactions, patchTransactionCategory } from "./controller";
-import { listTransactions, updateTransactionCategory } from "./service";
+import { getTransactions, patchTransactionCategory, postTransaction } from "./controller";
+import { createTransaction, listTransactions, updateTransactionCategory } from "./service";
 
 const requireSessionUserMock = jest.mocked(requireSessionUser);
 const listTransactionsMock = jest.mocked(listTransactions);
 const updateTransactionCategoryMock = jest.mocked(updateTransactionCategory);
+const createTransactionMock = jest.mocked(createTransaction);
 
 describe("transactions controller", () => {
   beforeEach(() => {
@@ -123,6 +125,36 @@ describe("transactions controller", () => {
       userUuid: "user-1",
       categoryUuid: "550e8400-e29b-41d4-a716-446655440001",
       subcategoryUuid: undefined,
+    });
+  });
+
+  it("creates a manual transaction for the authenticated user", async () => {
+    createTransactionMock.mockResolvedValueOnce({
+      ok: true,
+      data: { uuid: "txn-created" },
+    });
+
+    const response = await postTransaction(
+      new Request("http://localhost/api/transactions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          amount: 250,
+          recipientUuid: "550e8400-e29b-41d4-a716-446655440000",
+          type: "UPI",
+          timestamp: "2026-07-12T15:12:00.000Z",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect(createTransactionMock).toHaveBeenCalledWith({
+      userUuid: "user-1",
+      amount: 250,
+      recipientUuid: "550e8400-e29b-41d4-a716-446655440000",
+      type: "UPI",
+      timestamp: new Date("2026-07-12T15:12:00.000Z"),
+      source: "MANUAL",
     });
   });
 

--- a/src/server/page-data/transaction-create-page-data.ts
+++ b/src/server/page-data/transaction-create-page-data.ts
@@ -1,0 +1,21 @@
+import "server-only";
+
+import type { TransactionCreatePageInitialData } from "@/features/transactions/types";
+import { getCategories, getRecipients } from "@/lib/internal-api";
+import { requirePageSessionUser } from "@/server/auth/session";
+
+export async function getTransactionCreatePageData(): Promise<TransactionCreatePageInitialData> {
+  await requirePageSessionUser();
+
+  const [categories, recipients] = await Promise.all([
+    getCategories().catch(() => []),
+    getRecipients(
+      "?page=1&size=10&sortBy=transactionCount&sortOrder=desc",
+    ).catch(() => null),
+  ]);
+
+  return {
+    initialCategoriesData: categories,
+    initialRecipientsData: recipients?.recipients ?? [],
+  };
+}


### PR DESCRIPTION
## Summary

Adds a complete manual transaction creation flow to TrackCrow.

Users can now create transactions that were not captured through SMS or automatic imports, select or create recipients inline, classify payments, add optional metadata, and review the newly created transaction.

## Changes

- Added the responsive `/transactions/new` page.
- Added searchable recipient selection with frequent-recipient suggestions.
- Added inline recipient creation with duplicate detection and a one-tap **Use Existing Recipient** action.
- Added payment, classification, and optional-details sections.
- Added IST-aware date and time handling.
- Added a transaction summary, validation feedback, loading states, and unsaved-change protection.
- Redirects successful submissions to the new transaction detail page.
- Added **Add Transaction** actions to the transaction ledger.
- Added `POST /api/recipients` with normalized names and searchable text identifiers.
- Added service, controller, and form-model test coverage.

## Validation

- `pnpm lint`
- `pnpm test --runInBand`
- 32 test suites passed
- 184 tests passed

## Notes

- Transactions created through this flow use the `MANUAL` source.
- Currency remains fixed to INR.
- Location remains optional free-text metadata.
- No Prisma schema migration is required.
- Production build verification was skipped.